### PR TITLE
Fix 'UsedSpaceOnly, SkipHardwareTest, HardwareEncryption properties cannot be set to False'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,8 @@
 - Rename functions with improper Verb-Noun constructs
 - Add comment based help to any functions without it
 - Update Schema.mof Description fields
+- Fixes issue where Switch parameters are passed to Enable-Bitlocker even if
+  the corresponding DSC resource parameter was set to False (Issue #12)
 
 ## 1.2.0.0
 

--- a/Misc/xBitlockerCommon.psm1
+++ b/Misc/xBitlockerCommon.psm1
@@ -208,22 +208,22 @@ function Enable-BitlockerInternal
 
             if ($PSBoundParameters.ContainsKey("HardwareEncryption"))
             {
-                $params.Add("HardwareEncryption", $true)
+                $params.Add("HardwareEncryption", $HardwareEncryption)
             }
 
             if ($PSBoundParameters.ContainsKey("Service"))
             {
-                $params.Add("Service", $true)
+                $params.Add("Service", $Service)
             }
 
             if ($PSBoundParameters.ContainsKey("SkipHardwareTest"))
             {
-                $params.Add("SkipHardwareTest", $true)
+                $params.Add("SkipHardwareTest", $SkipHardwareTest)
             }
 
             if ($PSBoundParameters.ContainsKey("UsedSpaceOnly"))
             {
-                $params.Add("UsedSpaceOnly", $true)
+                $params.Add("UsedSpaceOnly", $UsedSpaceOnly)
             }
 
             #Now add the primary protector

--- a/Tests/Integration/MSFT_xBLAutoBitlocker.Integration.tests.ps1
+++ b/Tests/Integration/MSFT_xBLAutoBitlocker.Integration.tests.ps1
@@ -85,11 +85,6 @@ try
             }
 
             It 'Should have set the resource and all the parameters should match' {
-                $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
-                    $_.ConfigurationName -eq $configurationName `
-                    -and $_.ResourceId -eq "[$($script:dscResourceFriendlyName)]Integration_Test"
-                }
-
                 $fixedDriveBlvs = Get-BitLockerVolume | Where-Object -FilterScript {$_.VolumeType -eq 'Data'}
 
                 foreach ($fixedDriveBlv in $fixedDriveBlvs)

--- a/Tests/Integration/MSFT_xBLBitlocker.config.ps1
+++ b/Tests/Integration/MSFT_xBLBitlocker.config.ps1
@@ -20,7 +20,7 @@ else
 
 <#
     .SYNOPSIS
-        Enables Bitlocker on the Operating System drive using a TpmProtector
+        Enables Bitlocker on the Operating System drive using a TpmProtector.
 #>
 Configuration MSFT_xBLBitlocker_BasicTPMEncryptionOnSysDrive_Config
 {
@@ -32,6 +32,29 @@ Configuration MSFT_xBLBitlocker_BasicTPMEncryptionOnSysDrive_Config
         {
             MountPoint       = $env:SystemDrive
             PrimaryProtector = 'TpmProtector'
+            UsedSpaceOnly    = $true
+        }
+    }
+}
+
+<#
+    .SYNOPSIS
+        Enables Bitlocker on the Operating System drive using a TpmProtector
+        and passed multiple Switch parameters of Enable-Bitlocker with False
+        values.
+#>
+Configuration MSFT_xBLBitlocker_TPMEncryptionOnSysDriveWithFalseSwitchParams_Config
+{
+    Import-DscResource -ModuleName 'xBitlocker'
+
+    Node $AllNodes.NodeName
+    {
+        xBLBitlocker Integration_Test
+        {
+            MountPoint         = $env:SystemDrive
+            PrimaryProtector   = 'TpmProtector'
+            HardwareEncryption = $false
+            UsedSpaceOnly      = $false
         }
     }
 }

--- a/Tests/Integration/MSFT_xBLTpm.Integration.tests.ps1
+++ b/Tests/Integration/MSFT_xBLTpm.Integration.tests.ps1
@@ -73,11 +73,6 @@ try
             }
 
             It 'Should have set the resource and all the parameters should match' {
-                $resourceCurrentState = $script:currentConfiguration | Where-Object -FilterScript {
-                    $_.ConfigurationName -eq $configurationName `
-                    -and $_.ResourceId -eq "[$($script:dscResourceFriendlyName)]Integration_Test"
-                }
-
                 (Get-Tpm).TpmReady | Should -Be $true
             }
 

--- a/Tests/TestHelpers/xBitlockerTestHelper.psm1
+++ b/Tests/TestHelpers/xBitlockerTestHelper.psm1
@@ -42,3 +42,29 @@ function Test-HasPresentTpm
 
     return $hasReadyTpm
 }
+
+<#
+    .SYNOPSIS
+        Disables BitLocker on a test drive, if Enabled
+
+    .PARAMETER MountPoint
+        The MountPoint to disable BitLocker on
+#>
+function Disable-BitLockerOnTestDrive
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateNotNullorEmpty()]
+        [System.String]
+        $MountPoint
+    )
+
+    $blv = Get-BitLockerVolume -MountPoint $MountPoint
+
+    if ($blv.KeyProtector.Count -gt 0 -or $blv.ProtectionStatus -ne 'Off')
+    {
+        Disable-BitLocker -MountPoint $blv
+    }
+}


### PR DESCRIPTION
#### Pull Request (PR) description
Fixes issue where Switch parameters are passed to Enable-Bitlocker even if the corresponding DSC resource parameter was set to False.

#### This Pull Request (PR) fixes the following issues
- Fixes #12 

#### Task list
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xbitlocker/42)
<!-- Reviewable:end -->
