### PR TITLE
xBitLocker: Fix hashtables according to the style guideline

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Fix hashtables according to the style guideline.
+
 ## 1.4.0.0
 
 - Change double quoted string literals to single quotes

--- a/DSCResources/MSFT_xBLAutoBitlocker/MSFT_xBLAutoBitlocker.psm1
+++ b/DSCResources/MSFT_xBLAutoBitlocker/MSFT_xBLAutoBitlocker.psm1
@@ -367,7 +367,9 @@ function Set-TargetResource
     else
     {
         Remove-FromPSBoundParametersUsingHashtable -PSBoundParametersIn $PSBoundParameters -ParamsToRemove 'DriveType', 'MinDiskCapacityGB'
-        Add-ToPSBoundParametersFromHashtable -PSBoundParametersIn $PSBoundParameters -ParamsToAdd @{'MountPoint' = ''}
+        Add-ToPSBoundParametersFromHashtable -PSBoundParametersIn $PSBoundParameters -ParamsToAdd @{
+            'MountPoint' = ''
+        }
 
         # Loop through each potential AutoBitlocker volume, see whether they are enabled for Bitlocker, and if not, enable it
         foreach ($key in $autoBlVols.Keys)
@@ -575,7 +577,9 @@ function Test-TargetResource
     else
     {
         Remove-FromPSBoundParametersUsingHashtable -PSBoundParametersIn $PSBoundParameters -ParamsToRemove 'DriveType', 'MinDiskCapacityGB'
-        Add-ToPSBoundParametersFromHashtable -PSBoundParametersIn $PSBoundParameters -ParamsToAdd @{'MountPoint' = ''}
+        Add-ToPSBoundParametersFromHashtable -PSBoundParametersIn $PSBoundParameters -ParamsToAdd @{
+            'MountPoint' = ''
+        }
 
         # Check whether any potential AutoBitlocker volume is not currently enabled for Bitlocker, or doesn't have the correct settings
         foreach ($key in $autoBlVols.Keys)


### PR DESCRIPTION
<!--
    Thanks for submitting a Pull Request (PR) to this project.
    Your contribution to this project is greatly appreciated!

    Please prefix the PR title with the resource name,
    e.g. 'ResourceName: My short description'.
    If this is a breaking change, then also prefix the PR title
    with 'BREAKING CHANGE:',
    e.g. 'BREAKING CHANGE: ResourceName: My short description'.

    You may remove this comment block, and the other comment blocks, but please
    keep the headers and the task list.
-->
#### Pull Request (PR) description
- Changes to xBitlocker
  - Fix hashtables according to the style guideline.

#### This Pull Request (PR) fixes the following issues
None. Recently merged PSSA custom rules in the test framework would fail the tests unless these are resolved.

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md.
- [ ] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [x] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xbitlocker/53)
<!-- Reviewable:end -->
